### PR TITLE
Display headers as map in JSON output

### DIFF
--- a/json.c
+++ b/json.c
@@ -96,7 +96,7 @@ void fmt_msg_output_json (FILE *fp, const rd_kafka_message_t *rkmessage) {
                         size_t size;
 
                         JS_STR(g, "headers");
-                        yajl_gen_array_open(g);
+                        yajl_gen_map_open(g);
 
                         while (!rd_kafka_header_get_all(hdrs, idx++, &name,
                                                         &value, &size)) {
@@ -107,7 +107,7 @@ void fmt_msg_output_json (FILE *fp, const rd_kafka_message_t *rkmessage) {
                                         yajl_gen_null(g);
                         }
 
-                        yajl_gen_array_close(g);
+                        yajl_gen_map_close(g);
                 }
         }
 #endif

--- a/json.c
+++ b/json.c
@@ -90,7 +90,6 @@ void fmt_msg_output_json (FILE *fp, const rd_kafka_message_t *rkmessage) {
                 rd_kafka_headers_t *hdrs;
 
                 if (!rd_kafka_message_headers(rkmessage, &hdrs)) {
-                        size_t idx = 0;
                         const char *name;
                         const void *value;
                         size_t size;
@@ -98,13 +97,20 @@ void fmt_msg_output_json (FILE *fp, const rd_kafka_message_t *rkmessage) {
                         JS_STR(g, "headers");
                         yajl_gen_map_open(g);
 
-                        while (!rd_kafka_header_get_all(hdrs, idx++, &name,
+                        while (!rd_kafka_header_get_all(hdrs, 0, &name,
                                                         &value, &size)) {
                                 JS_STR(g, name);
-                                if (value)
-                                        yajl_gen_string(g, value, size);
-                                else
-                                        yajl_gen_null(g);
+                                size_t idx = 0;
+                                yajl_gen_array_open(g);
+                                while (!rd_kafka_header_get(hdrs, idx++, name,
+                                                            &value, &size)) {
+                                        if (value)
+                                                yajl_gen_string(g, value, size);
+                                        else
+                                                yajl_gen_null(g);
+                                }
+                                yajl_gen_array_close(g);
+                                rd_kafka_header_remove(hdrs, name);
                         }
 
                         yajl_gen_map_close(g);

--- a/json.c
+++ b/json.c
@@ -90,30 +90,47 @@ void fmt_msg_output_json (FILE *fp, const rd_kafka_message_t *rkmessage) {
                 rd_kafka_headers_t *hdrs;
 
                 if (!rd_kafka_message_headers(rkmessage, &hdrs)) {
+                        size_t idx;
                         const char *name;
                         const void *value;
                         size_t size;
 
                         JS_STR(g, "headers");
-                        yajl_gen_map_open(g);
+                        if (conf.flags & CONF_F_HDR_JSON_MAP) {
+                                yajl_gen_map_open(g);
 
-                        while (!rd_kafka_header_get_all(hdrs, 0, &name,
-                                                        &value, &size)) {
-                                JS_STR(g, name);
-                                size_t idx = 0;
+                                while (!rd_kafka_header_get_all(hdrs, 0, &name,
+                                                                &value, &size)) {
+                                        JS_STR(g, name);
+                                        idx = 0;
+                                        yajl_gen_array_open(g);
+                                        while (!rd_kafka_header_get(hdrs, idx++, name,
+                                                                    &value, &size)) {
+                                                if (value)
+                                                        yajl_gen_string(g, value, size);
+                                                else
+                                                        yajl_gen_null(g);
+                                        }
+                                        yajl_gen_array_close(g);
+                                        rd_kafka_header_remove(hdrs, name);
+                                }
+
+                                yajl_gen_map_close(g);
+                        } else {
                                 yajl_gen_array_open(g);
-                                while (!rd_kafka_header_get(hdrs, idx++, name,
-                                                            &value, &size)) {
+
+                                idx = 0;
+                                while (!rd_kafka_header_get_all(hdrs, idx++, &name,
+                                                                &value, &size)) {
+                                        JS_STR(g, name);
                                         if (value)
                                                 yajl_gen_string(g, value, size);
                                         else
                                                 yajl_gen_null(g);
                                 }
-                                yajl_gen_array_close(g);
-                                rd_kafka_header_remove(hdrs, name);
-                        }
 
-                        yajl_gen_map_close(g);
+                                yajl_gen_array_close(g);
+                        }
                 }
         }
 #endif

--- a/kcat.c
+++ b/kcat.c
@@ -1428,6 +1428,9 @@ static void RD_NORETURN usage (const char *argv0, int exitcode,
                 "                     Takes precedence over -D and -K.\n"
 #if ENABLE_JSON
                 "  -J                 Output with JSON envelope\n"
+#if HAVE_HEADERS
+                "  -n                 Display headers as map\n"
+#endif
 #endif
                 "  -s key=<serdes>    Deserialize non-NULL keys using <serdes>.\n"
                 "  -s value=<serdes>  Deserialize non-NULL values using <serdes>.\n"
@@ -2088,7 +2091,7 @@ static void argparse (int argc, char **argv,
 
         while ((opt = getopt(argc, argv,
                              ":PCG:LQM:t:p:b:z:o:eED:K:k:H:Od:qvF:X:c:Tuf:ZlVh"
-                             "s:r:Jm:U")) != -1) {
+                             "s:r:Jnm:U")) != -1) {
                 switch (opt) {
                 case 'P':
                 case 'C':
@@ -2184,6 +2187,13 @@ static void argparse (int argc, char **argv,
                 case 'J':
 #if ENABLE_JSON
                         conf.flags |= CONF_F_FMT_JSON;
+#else
+                        KC_FATAL("This build of kcat lacks JSON support");
+#endif
+                        break;
+                case 'n':
+#if ENABLE_JSON && HAVE_HEADERS
+                        conf.flags |= CONF_F_HDR_JSON_MAP;
 #else
                         KC_FATAL("This build of kcat lacks JSON support");
 #endif

--- a/kcat.h
+++ b/kcat.h
@@ -106,6 +106,7 @@ struct conf {
 #define CONF_F_FMT_AVRO_KEY   0x400 /* Convert key from Avro to JSON */
 #define CONF_F_FMT_AVRO_VALUE 0x800 /* Convert value from Avro to JSON  */
 #define CONF_F_SR_URL_SEEN    0x1000 /* schema.registry.url/-r seen */
+#define CONF_F_HDR_JSON_MAP   0x2000 /* Display headers as map in JSON */
         char   *delim;
         size_t  delim_size;
         char   *key_delim;


### PR DESCRIPTION
In the help, they are presented as a map for consuming with `-J`.
But they are currently displayed as a list `[key1, value1, key2, value2, ...]`.

Before:

```json
{"topic":"test","partition":0,"offset":4,"tstype":"create","ts":1603987358147,"broker":1,"headers":["header1","header value","nullheader",null,"emptyheader","","header1","duplicateIsOk"],"key":null,"payload":"toto"}
{"topic":"test","partition":0,"offset":5,"tstype":"create","ts":1603987360383,"broker":1,"headers":["header1","header value","nullheader",null,"emptyheader","","header1","duplicateIsOk"],"key":null,"payload":"tata"}
{"topic":"test","partition":0,"offset":6,"tstype":"create","ts":1603987361934,"broker":1,"headers":["header1","header value","nullheader",null,"emptyheader","","header1","duplicateIsOk"],"key":null,"payload":"tutu"}
{"topic":"test","partition":0,"offset":7,"tstype":"create","ts":1603987363306,"broker":1,"headers":["header1","header value","nullheader",null,"emptyheader","","header1","duplicateIsOk"],"key":null,"payload":"titi"}
```

After:

```json
{"topic":"test","partition":0,"offset":4,"tstype":"create","ts":1603987358147,"broker":1,"headers":{"header1":"header value","nullheader":null,"emptyheader":"","header1":"duplicateIsOk"},"key":null,"payload":"toto"}
{"topic":"test","partition":0,"offset":5,"tstype":"create","ts":1603987360383,"broker":1,"headers":{"header1":"header value","nullheader":null,"emptyheader":"","header1":"duplicateIsOk"},"key":null,"payload":"tata"}
{"topic":"test","partition":0,"offset":6,"tstype":"create","ts":1603987361934,"broker":1,"headers":{"header1":"header value","nullheader":null,"emptyheader":"","header1":"duplicateIsOk"},"key":null,"payload":"tutu"}
{"topic":"test","partition":0,"offset":7,"tstype":"create","ts":1603987363306,"broker":1,"headers":{"header1":"header value","nullheader":null,"emptyheader":"","header1":"duplicateIsOk"},"key":null,"payload":"titi"}
```