### PR TITLE
Fix Docker Debian image build

### DIFF
--- a/Dockerfile.Debian
+++ b/Dockerfile.Debian
@@ -12,7 +12,7 @@ RUN apt-get update && \
   rm -rf tmp-bootstrap && \
   echo "Source versions:" && \
   grep ^github_download ./bootstrap.sh && \
-  ./bootstrap.sh && \
+  ./bootstrap.sh --no-enable-static && \
   mv kcat /usr/bin/ ; \
   echo "Cleaning up" ; \
   cd / ; \


### PR DESCRIPTION
I attempted to build the Debian Docker image and it failed. By adding the `--no-enable-static` string (which is present in the Alpine image) it succeeds.

There may be a way to fix the compile error and get a static build to work. That would likely be a better fix than this workaround.