### PR TITLE
Add github workflow to build containers

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,50 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
+name: Build container images
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  docker:
+    name: Publish container images
+    runs-on: ubuntu-latest
+    steps:
+      # Action reference: https://github.com/actions/checkout
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      # Action reference: https://github.com/docker/metadata-action
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: edenhill/kcat
+
+      # Action reference: https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU (for docker buildx)
+        uses: docker/setup-qemu-action@v1
+
+      # Action reference: https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      # Action reference: https://github.com/docker/login-action
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Action reference: https://github.com/docker/build-push-action
+      - name: Build container image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+


### PR DESCRIPTION
This workflow should automatically push a multi-arch container image build whenever a tag is created.

Fixes: #324
