### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+kafkacat (1.6.0-2) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster:
+    + Build-Depends: Drop versioned constraint on librdkafka-dev and
+      libyajl-dev.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Fri, 18 Feb 2022 16:00:55 -0000
+
 kafkacat (1.6.0-1) unstable; urgency=medium
 
   * New upstream release.

--- a/debian/control
+++ b/debian/control
@@ -4,11 +4,11 @@ Priority: optional
 Maintainer: Vincent Bernat <bernat@debian.org>
 Uploaders: Faidon Liambotis <paravoid@debian.org>
 Build-Depends: debhelper-compat (= 13),
-               librdkafka-dev (>= 0.9.0),
+               librdkafka-dev,
                libavro-dev,
                pkg-config,
                zlib1g-dev,
-               libyajl-dev (>= 2)
+               libyajl-dev
 Standards-Version: 4.5.0
 Homepage: https://github.com/edenhill/kafkacat
 Vcs-Browser: https://github.com/edenhill/kafkacat/tree/debian


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/kafkacat/57c3efa5-748f-4537-bb88-aa1ac03f5794.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/57c3efa5-748f-4537-bb88-aa1ac03f5794/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/57c3efa5-748f-4537-bb88-aa1ac03f5794/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/57c3efa5-748f-4537-bb88-aa1ac03f5794/diffoscope)).
